### PR TITLE
ビルドエラー回避のため、プロジェクトのプロパティを変更

### DIFF
--- a/TTBasePlugin.vcxproj
+++ b/TTBasePlugin.vcxproj
@@ -98,8 +98,8 @@
       <Optimization>Disabled</Optimization>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <WarningLevel>Level4</WarningLevel>
-      <MinimalRebuild>true</MinimalRebuild>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <MinimalRebuild>false</MinimalRebuild>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;VC_EXPORTS;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
       <BrowseInformation>true</BrowseInformation>
@@ -139,7 +139,8 @@
       <ModuleDefinitionFile>TTBasePlugin.def</ModuleDefinitionFile>
     </Link>
     <Manifest>
-      <AdditionalManifestFiles>..\x86.manifest</AdditionalManifestFiles>
+      <AdditionalManifestFiles>
+      </AdditionalManifestFiles>
     </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -190,7 +191,8 @@
       <ModuleDefinitionFile>TTBasePlugin.def</ModuleDefinitionFile>
     </Link>
     <Manifest>
-      <AdditionalManifestFiles>..\amd64.manifest</AdditionalManifestFiles>
+      <AdditionalManifestFiles>
+      </AdditionalManifestFiles>
     </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">


### PR DESCRIPTION
度々お世話になります。

Visual Studio Community 2015でビルドしようとすると、下記のビルドエラーが発生します。

構成：Debug|Win32

> D8016 - コマンド ライン オプション '/ZI' と '/Gy-' は同時に指定できません
> D9030 - '/Gm' はマルチプロセシングと互換性がありません。/MP スイッチを無視します
> LNK1104 - ファイル '..\x86.manifest' を開くことができません。

構成：Debug|x64

> LNK1104 - ファイル '..\amd64.manifest' を開くことができません。

ビルドを通すため、プロジェクトのプロパティを、下記の通り変更しました。
- デバッグ情報の形式を /ZI から /Zi へ変更
- 最小リビルドの有効／無効を /Gm から /Gm- へ変更
- 追加のマニフェストファイルから '..\x86.manifest' '..\amd64.manifest' の参照を削除

よろしければご確認ください。
